### PR TITLE
#3 fix: 에러 로그 저장시 메시지 사이즈로 인한 오류

### DIFF
--- a/src/main/java/io/migni/central/data/server/application/global/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/migni/central/data/server/application/global/web/exception/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
         this.logger.error("[Error] Sequence - {}", requestSequence);
         em.createNativeQuery("INSERT INTO error_log(request_sequence, message) VALUES (?, ?)")
             .setParameter(1, requestSequence)
-            .setParameter(2, exception.getMessage())
+            .setParameter(2, exception.getClass().getName())
             .executeUpdate();
 
         return ResponseEntity


### PR DESCRIPTION
* 에러 클래스 이름으로 저장하여 에러 로그 관리

Resolves: #3
See also: None